### PR TITLE
Support for buffers with more than 2 channels

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ module.exports = audioBufferToWav
 function audioBufferToWav (buffer, opt) {
   opt = opt || {}
 
-  var numChannels = buffer.numberOfChannels
+  var numChannels = Math.min(buffer.numberOfChannels, 2)
   var sampleRate = buffer.sampleRate
   var format = opt.float32 ? 3 : 1
   var bitDepth = format === 3 ? 32 : 16


### PR DESCRIPTION
<!--
Please make sure to read the Contributing Guidelines:
https://github.com/Jam3/.github/CONTRIBUTING.md
-->

<!--- Provide a general summary of your changes in the PR Title -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Code style update
- [ ] Refactor (refactoring or adding test which isn't a fix or add a feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Did you test your solution?**

- [x] I lightly tested it in one browser
- [ ] I deeply tested it in several browsers
- [ ] I wrote tests around it (unit tests, integration tests, E2E tests)

## Problem Description

If the audio buffer contains more than 2 channels, it defaults to using the first channel rather than interleaving the first 2 channels.

## Solution Description

By using Math.min, the channel count is forced to 2, meaning it will always interleave if 2 channels are available.

## Side Effects, Risks, Impact

- [x] N/A

**Additional comments:**
